### PR TITLE
Make syntax_ok check modules without '::' in their names

### DIFF
--- a/lib/Test/Strict.pm
+++ b/lib/Test/Strict.pm
@@ -500,7 +500,6 @@ sub _taint_switch {
 ##
 sub _module_to_path {
   my $file = shift;
-  return $file unless ($file =~ /::/);
   my @parts = split /::/, $file;
   my $module = File::Spec->catfile(@parts) . '.pm';
   foreach my $dir (@INC) {


### PR DESCRIPTION
Currently, syntax_ok() checks modules' syntax only if the name
contains '::', i.e. syntax_ok("My::Module") works while
syntax_ok("MyModule") doesn't.  This patch fixes this behaviour.

We still treat the argument as a file path in case no such module
exists.

This is already covered by the test suite.

Signed-off-by: Petr Šabata <contyk@redhat.com>