### PR TITLE
Change _warnings_ok() to get multiple switches

### DIFF
--- a/lib/Test/Strict.pm
+++ b/lib/Test/Strict.pm
@@ -357,7 +357,7 @@ sub _warnings_ok {
   my ($is_script, $in) = @_;
   while (<$in>) {
     if ($. == 1 and $is_script and $_ =~ $PERL_PATTERN) {
-      if (/perl\s+\-\w*[wW]/) {
+      if (/\s+-\w*[wW]/) {
         return 1;
       }
     }

--- a/t/01all.t
+++ b/t/01all.t
@@ -15,7 +15,7 @@ if ($^O =~ /MSWin/i) { # Load Win32 if we are under Windows and if module is ava
   }
 }
 
-my $tests = 45;
+my $tests = 48;
 $tests += 2 if -e 'blib/lib/Test/Strict.pm';
 plan  tests => $tests;
 
@@ -178,6 +178,15 @@ print "Hello world";
 
 DUMMY
   push @files, $filename4;
+
+  my ($fh5, $filename5) = tempfile( DIR => $tmpdir, SUFFIX => '.pl' );
+  print $fh5 <<'DUMMY';
+#!/usr/bin/perl -T -w
+use strict;
+print "Hello world";
+
+DUMMY
+  push @files, $filename5;
 
   return ($tmpdir, \@files, $filename3);
 }


### PR DESCRIPTION
In its previous format, _warnings_ok would not get the following:
 #!/bin/perl -t -w
Which should also be accepted.

Also, there is no need for checking for 'perl' in the second regex check since
it has been checked before.

Last, removed the '\' escaping '-' since that was just a no op.